### PR TITLE
Allow setting bridge address from context or input

### DIFF
--- a/MiLight.html
+++ b/MiLight.html
@@ -8,11 +8,19 @@
             bulbtype: {value:"white"},
             zone: {value:1,oneditsave:function(){this.zone=parseInt(this.zone)}},
             ip: {value:"255.255.255.255"},
+            ipType: {value:"str"},
             broadcast: {value:true}
         },
         inputs:1,
         outputs:0,
         icon: "light.png",
+        oneditprepare: () => {
+            $("#node-input-ip").typedInput({
+                type: "str",
+                types: ["str", "msg", "flow","global"],
+                typeField: "#node-input-ipType"
+            });
+        },
         label: function() {
             return this.name||"MiLight";
         }
@@ -49,6 +57,7 @@
     <div class="form-row">
         <label for="node-input-ip">IP Address</label>
         <input type="text" id="node-input-ip" placeholder="255.255.255.255">
+        <input type="hidden" id="node-input-ipType">
     </div>
     <div class="form-row">
         <label for="node-input-broadcast">Broadcast</label>


### PR DESCRIPTION
My Milight ibox1 sometimes changes IP and node-red was unable to send commands to it, until I ran bridge discovery to find out new ip and updated address in milight node. This is very annoying.

This PR allows setting bridge address from context or from input.

This allows me to have another flow that does periodic bridge discovery and updates bridge ip in global context and milight node uses that global context. Now, changing IPs are handled automatically.